### PR TITLE
Shields can now be stolen by like-like

### DIFF
--- a/alttpo/LocalGameState.as
+++ b/alttpo/LocalGameState.as
@@ -3,8 +3,6 @@ const uint MaxPacketSize = 1452;
 
 const uint OverworldAreaCount = 0x82;
 
-uint8 gotShield;
-
 class ALTTPSRAMArray : SRAMArray {
   bool is_buffer;
 
@@ -82,6 +80,8 @@ class LocalGameState : GameState {
 
   uint8 state;
   uint32 last_sent = 0;
+  
+  uint8 gotShield;
   
   AncillaTables ancillaTables;
   array<Projectile> projectiles;

--- a/alttpo/LocalGameState.as
+++ b/alttpo/LocalGameState.as
@@ -3,6 +3,8 @@ const uint MaxPacketSize = 1452;
 
 const uint OverworldAreaCount = 0x82;
 
+uint8 gotShield;
+
 class ALTTPSRAMArray : SRAMArray {
   bool is_buffer;
 
@@ -80,7 +82,7 @@ class LocalGameState : GameState {
 
   uint8 state;
   uint32 last_sent = 0;
-
+  
   AncillaTables ancillaTables;
   array<Projectile> projectiles;
 
@@ -150,6 +152,8 @@ class LocalGameState : GameState {
 
     small_keys_current.reset();
     last_sent = 0;
+    
+    gotShield = 0;
   }
 
   bool registered = false;

--- a/alttpo/SyncableItem.as
+++ b/alttpo/SyncableItem.as
@@ -327,17 +327,17 @@ uint16 mutateSword(SRAM@ localSRAM, uint16 oldValue, uint16 newValue) {
 }
 
 uint16 mutateShield(SRAM@ localSRAM, uint16 oldValue, uint16 newValue) {
-  if(gotShield == 0)
+  if(local.gotShield == 0)
   {
-    gotShield = newValue;
+    local.gotShield = newValue;
   }
-  if (newValue > oldValue && newValue > gotShield) {
+  if (newValue > oldValue && newValue > local.gotShield) {
     if (rom.is_alttp()) {
       // JSL DecompShieldGfx
       pb.jsl(rom.fn_decomp_shield_gfx);
       pb.jsl(rom.fn_shield_palette);
     }
-    gotShield = newValue;
+    local.gotShield = newValue;
     return newValue;
   }
   return oldValue;

--- a/alttpo/SyncableItem.as
+++ b/alttpo/SyncableItem.as
@@ -38,8 +38,6 @@ funcdef uint16 ItemMutate(SRAM@ localSRAM, uint16 oldValue, uint16 newValue);
 funcdef void NotifyItemReceived(const string &in name);
 funcdef void NotifyNewItems(uint16 oldValue, uint16 newValue, NotifyItemReceived @notify);
 
-uint8 gotShield;
-
 // list of SRAM values to sync as items:
 class SyncableItem {
   uint16  offs;   // SRAM offset from $7EF000 base address

--- a/alttpo/SyncableItem.as
+++ b/alttpo/SyncableItem.as
@@ -38,6 +38,8 @@ funcdef uint16 ItemMutate(SRAM@ localSRAM, uint16 oldValue, uint16 newValue);
 funcdef void NotifyItemReceived(const string &in name);
 funcdef void NotifyNewItems(uint16 oldValue, uint16 newValue, NotifyItemReceived @notify);
 
+uint8 gotShield;
+
 // list of SRAM values to sync as items:
 class SyncableItem {
   uint16  offs;   // SRAM offset from $7EF000 base address
@@ -327,12 +329,17 @@ uint16 mutateSword(SRAM@ localSRAM, uint16 oldValue, uint16 newValue) {
 }
 
 uint16 mutateShield(SRAM@ localSRAM, uint16 oldValue, uint16 newValue) {
-  if (newValue > oldValue) {
+  if(gotShield == 0)
+  {
+    gotShield = newValue;
+  }
+  if (newValue > oldValue && newValue > gotShield) {
     if (rom.is_alttp()) {
       // JSL DecompShieldGfx
       pb.jsl(rom.fn_decomp_shield_gfx);
       pb.jsl(rom.fn_shield_palette);
     }
+    gotShield = newValue;
     return newValue;
   }
   return oldValue;


### PR DESCRIPTION
Shields can now be stolen by like-like.
Just a tiny fix but very helpful especially for german ROMS because these did crash and corrupt your save file every time this guy eats your shield.