### PR TITLE
Vanilla sm and notifications

### DIFF
--- a/alttpo/GameState.as
+++ b/alttpo/GameState.as
@@ -1209,10 +1209,10 @@ class GameState {
     }
     //load data from vram into sprs
     
-    for (int i = 0; i < len1; i++) {
+    for (uint16 i = 0; i < len1; i++) {
         bus::read_block_u16(transfer0 + 0x20 * i, 0, 16, sprs[i]);
     }
-    for (int i = 0; i < len2; i++) {
+    for (uint16 i = 0; i < len2; i++) {
         bus::read_block_u16(transfer1 + 0x20 * i, 0, 16, sprs[i+16]);
     }
     

--- a/alttpo/ROMMapping.as
+++ b/alttpo/ROMMapping.as
@@ -660,6 +660,38 @@ class SMZ3Mapping : RandomizerMapping {
   }
 }
 
+class VanillaSMMappping : ROMMapping{
+
+  VanillaSMMappping() {
+    super();
+    update_syncables();
+  }
+  
+  void update_syncables() {
+    //metroid items
+    syncables = {@SyncableItem(0x02, 1, 2, @nameForMetroidSuits, true),
+                 @SyncableItem(0x03, 1, 2, @nameForMetroidBoots, true),
+                 @SyncableItem(0x06, 1, 2, @nameForMetroidBeams, true),
+                 @SyncableItem(0x07, 1, 1, null, true), // charge beam
+                 @SyncableItem(0x26, 1, 1, null, true), // missile capacity
+                 @SyncableItem(0x2a, 1, 1, null, true), // super missile capacity
+                 @SyncableItem(0x2e, 1, 1, null, true), // power bomb capacity
+                 @SyncableItem(0x32, 2, 1, null, true), // reserve tanks
+                 @SyncableItem(0x22, 2, 1, null, true), // energy tanks
+                };
+  }
+  
+  bool is_alttp() override { return false; }
+  bool is_smz3() override { return true;}
+
+  void register_pc_intercepts() override {
+    // SM main is at 0x82893D (PHK; PLB)
+    // SM main @loop (PHP; REP #$30) https://github.com/strager/supermetroid/blob/master/src/bank82.asm#L1066
+    cpu::register_pc_interceptor(0x828948, @on_main_sm);
+  }
+
+}
+
 ROMMapping@ detect() {
   array<uint8> sig(21);
   bus::read_block_u8(0x00FFC0, 0, 21, sig);
@@ -740,6 +772,9 @@ ROMMapping@ detect() {
     auto kind = title.slice(0, 3) + " v" + title.slice(3, 4);
     message("Recognized " + kind + " randomized ROM version. Seed: " + seed);
     return SMZ3Mapping(kind, seed);
+  } else if(title.slice(0, 13) == "Super Metroid"){
+      message("recognized vanilla SM");
+      return VanillaSMMappping();
   } else {
     switch (region) {
       case 0x00:

--- a/alttpo/SyncableItem.as
+++ b/alttpo/SyncableItem.as
@@ -171,14 +171,33 @@ class SyncableItem {
         bus::write_u8(base + offs - 2, enew);
         break;
       case 0x26:
+        old_count = bus::read_u8(base + offs - 2);
+        diff = newValue - oldValue;
+        bus::write_u8(base + offs - 2, old_count + diff);
+        local.notify("Got " + fmtInt(diff) + " Missiles");
+        break;
       case 0x2a:
+        old_count = bus::read_u8(base + offs - 2);
+        diff = newValue - oldValue;
+        bus::write_u8(base + offs - 2, old_count + diff);
+        local.notify("Got " + fmtInt(diff) + " Super Missiles");
+        break;
       case 0x2e:
         old_count = bus::read_u8(base + offs - 2);
         diff = newValue - oldValue;
         bus::write_u8(base + offs - 2, old_count + diff);
+        local.notify("Got " + fmtInt(diff) + " Power Bombs");
         break;
       case 0x22:
         bus::write_u16(base + offs - 2, bus::read_u16(base + offs));
+        diff = newValue - oldValue;
+        if (diff/100 == 1) local.notify("Got " + fmtInt(diff/100) + " Energy Tank");
+        else local.notify("Got " + fmtInt(diff/100) + " Energy Tanks");
+        break;
+       case 0x32:
+        diff = newValue - oldValue;
+        if (diff/100 == 1) local.notify("Got " + fmtInt(diff/100) + " Reserve Tank");
+        else local.notify("Got " + fmtInt(diff/100) + " Reserve Tanks");
         break;
       default: return;
     }


### PR DESCRIPTION
Added a vanillaSM class to detect the vanilla super metroid ROM, functions as expected, with all the expected bugs

updated the typing of a dummy variable in GameState to avoid a sign/unsign warning

Updated the update_sm_counts() method to notify the player when they recieve missiles, super missiles, power bombs, energy tanks, or reserve tanks. and how many of each.

The notification code is a bit repetitive, and could probably be slimmed down a little