### PR TITLE
Unstable smz3

### DIFF
--- a/alttpo/GameState.as
+++ b/alttpo/GameState.as
@@ -1150,11 +1150,11 @@ class GameState {
     
     //initialize tile
     auto @tile = ppu::extra[ei++];
-    tile.index = 0;
-    tile.source = 5;
+    tile.index = 127;
+    tile.source = 4;
     tile.x = x + offsx;
     tile.y = y + offsy;
-    tile.priority = 261;
+    tile.priority = 0x106; //0x106-0x108
     tile.hflip = false;
     tile.vflip = false;
     tile.width = 64;

--- a/alttpo/GameState.as
+++ b/alttpo/GameState.as
@@ -1098,6 +1098,31 @@ class GameState {
 
     return ei;
   }
+  
+  int render_sm_label(int dx, int dy, int ei) {
+
+    // render player name as text:
+    auto @label = ppu::extra[ei++];
+    label.reset();
+    label.index = 127;
+    label.source = 4;
+    label.priority = 0x106;
+
+    // measure player name to set bounds of tile with:
+    auto width = ppu::extra.font.measureText(_name);
+    label.width = width + 2;
+    label.height = ppu::extra.font.height + 2;
+
+    // render player name as text into tile, making room for 1px outline:
+    ppu::extra.color = player_color;
+    ppu::extra.outline_color = player_color_dark_33;
+    label.text(1, 1, _name);
+
+    label.x = (x - xoffs + dx + 8) - (label.width >> 1);
+    label.y = (y - yoffs + 17 + dy) + 8;
+
+    return ei;
+  }
 
   uint8 adjust_sfx_pan(uint8 sfx) {
     // Try to infer the sound's relative(ish) position from the remote player

--- a/alttpo/GameState.as
+++ b/alttpo/GameState.as
@@ -1305,6 +1305,8 @@ class GameState {
         case 0x1f: return 4;
         case 0x27: return 2;
         case 0x28: return 2;
+        case 0x29: return 1;
+        case 0x2a: return 1;
         case 0x31: return 4;
         case 0x32: return 4;
         case 0x38: return 3;
@@ -1330,6 +1332,7 @@ class GameState {
         case 0x80: return 4;
         case 0x81: return 5;
         case 0x82: return 5;
+        case 0x9b: return 1;
         case 0xa4: return 7;
         case 0xa5: return 7;
         default: return 0;

--- a/alttpo/GameState.as
+++ b/alttpo/GameState.as
@@ -1346,7 +1346,7 @@ class GameState {
         case 0x06: return -22;
         case 0x08: return -22;
         
-        default: return -15;
+        default: return -13;
     }
     
     

--- a/alttpo/LocalGameState.as
+++ b/alttpo/LocalGameState.as
@@ -1082,11 +1082,11 @@ class LocalGameState : GameState {
     for (int i = 0; i < 0x12; i++) {
       sm_events[i] = bus::read_u8(0x7ED820 + i);
     }
-    for (int i = 0x50; i < 0x70; i++) {
-      sm_events[i - 0x40] = bus::read_u8(0x7ED820 + i);
+    for (int i = 0; i < 0x20; i++) {
+      sm_events[i + 0x12] = bus::read_u8(0x7ED870 + i);
     }
-    for (int i = 0x90; i < 0xB0; i++) {
-      sm_events[i - 0x60] = bus::read_u8(0x7ED820 + i);
+    for (int i = 0; i < 0x20; i++) {
+      sm_events[i + 0x12 + 0x20] = bus::read_u8(0x7ED8B0 + i);
     }
   }
   
@@ -2399,14 +2399,14 @@ class LocalGameState : GameState {
       }
     }
 
-    for (int i = 0; i < 0x10; i++) {
+    for (int i = 0; i < 0x12; i++) {
       bus::write_u8(0x7ED820 + i, sm_events[i]);
     }
-    for (int i = 0x50; i < 0x70; i++) {
-      bus::write_u8(0x7ED820 + i, sm_events[i - 0x40]);
+    for (int i = 0; i < 0x20; i++) {
+      bus::write_u8(0x7ED870 + i, sm_events[i + 0x12]);
     }
-    for (int i = 0x90; i < 0xB0; i++) {
-      bus::write_u8(0x7ED820 + i, sm_events[i - 0x60]);
+    for (int i = 0; i < 0x20; i++) {
+      bus::write_u8(0x7ED8B0 + i, sm_events[i + 0x12 + 0x20]);
     }
   }
   

--- a/alttpo/LocalGameState.as
+++ b/alttpo/LocalGameState.as
@@ -2501,11 +2501,27 @@ class LocalGameState : GameState {
     bus::read_block_u16(0x7eC180, 0, sm_palette.length(), sm_palette);
   }
   
+  bool deselect_tunic_sync_sm;
   void update_sm_palette(){
     sm_palette[1] = player_color_dark_33;
     sm_palette[2] = player_color;
     sm_palette[11] = player_color_dark_33;
     sm_palette[10] = player_color_dark_50;
+  }
+  
+  void update_local_suit(){
+    if(!rom.is_alttp()){
+    if(settings.SyncTunic){
+      bus::write_u16(0x7ec182, player_color_dark_33);
+      bus::write_u16(0x7ec184, player_color);
+      bus::write_u16(0x7ec196, player_color_dark_33);
+      bus::write_u16(0x7ec194, player_color_dark_33);
+     } else if(deselect_tunic_sync_sm){
+      bus::write_u16(0x7e0a48, 0x06);
+     }
+  }
+  
+  deselect_tunic_sync_sm = settings.SyncTunic;
   }
 
   // detect attacks from us against all nearby players:

--- a/alttpo/post_frame.as
+++ b/alttpo/post_frame.as
@@ -95,6 +95,8 @@ void post_frame() {
   if (memoryWindow !is null) {
     memoryWindow.update();
   }
+  
+  local.update_local_suit();
 
   if (settings.EnablePvP && debugData) {
     uint len = players.length();

--- a/alttpo/pre_frame.as
+++ b/alttpo/pre_frame.as
@@ -119,6 +119,10 @@ bool sm_loading_room() {
   return sm_state == 0x0b;
 }
 
+bool sm_in_menu(){
+  return (sm_state >= 0x0c && sm_state <= 0x12);
+}
+
 // Super Metroid main loop intercept:
 void on_main_sm(uint32 pc) {
   //message("main_sm");
@@ -132,7 +136,7 @@ void on_main_sm(uint32 pc) {
   local.get_sm_coords();
   local.fetch_sm_events();
   local.fetch_games_won();
-  if (sm_state < 0x0c || sm_state > 0x12){ 
+  if (!sm_in_menu()){ 
     local.get_sm_sprite_data();
     if (settings.SyncTunic){
       local.update_sm_palette();
@@ -296,7 +300,7 @@ void pre_frame() {
       if (enableRenderToExtra) {
         ei = remote.renderToExtra(rx, ry, ei);
 
-        if (settings.ShowLabels) {
+        if (settings.ShowLabels && ! sm_in_menu()) {
           ei = remote.renderLabel(rx, ry, ei);
         }
       } else {
@@ -330,7 +334,7 @@ void pre_frame() {
         ei = local.renderNotifications(ei);
       }
       
-      if (settings.ShowMyLabel && !sm_loading_room()){
+      if (settings.ShowMyLabel && !sm_loading_room() && !sm_in_menu()){
         int offset_x = int(bus::read_u16(0x7e0b04));
         int offset_y = int(bus::read_u16(0x7e0b06));
         

--- a/alttpo/pre_frame.as
+++ b/alttpo/pre_frame.as
@@ -330,7 +330,7 @@ void pre_frame() {
         ei = local.renderNotifications(ei);
       }
       
-      if (settings.ShowMyLabel){
+      if (settings.ShowMyLabel && !sm_loading_room){
         int offset_x = int(bus::read_u16(0x7e0b04));
         int offset_y = int(bus::read_u16(0x7e0b06));
         

--- a/alttpo/pre_frame.as
+++ b/alttpo/pre_frame.as
@@ -330,7 +330,7 @@ void pre_frame() {
         ei = local.renderNotifications(ei);
       }
       
-      if (settings.ShowMyLabel && !sm_loading_room){
+      if (settings.ShowMyLabel && !sm_loading_room()){
         int offset_x = int(bus::read_u16(0x7e0b04));
         int offset_y = int(bus::read_u16(0x7e0b06));
         

--- a/alttpo/pre_frame.as
+++ b/alttpo/pre_frame.as
@@ -272,6 +272,10 @@ void pre_frame() {
       
       
       ei = remote.draw_samus(rx, ry, ei);
+      
+      if (settings.ShowLabels){
+          ei = remote.render_sm_label(rx - 8, ry - 64, ei);
+      }
     
       continue;
     }
@@ -324,6 +328,13 @@ void pre_frame() {
       sm_state = bus::read_u8(0x7E0998);
       if (sm_is_safe_state()) {
         ei = local.renderNotifications(ei);
+      }
+      
+      if (settings.ShowMyLabel){
+        int offset_x = int(bus::read_u16(0x7e0b04));
+        int offset_y = int(bus::read_u16(0x7e0b06));
+        
+        ei = local.render_sm_label(offset_x - 8, offset_y - 64, ei);
       }
     }
 


### PR DESCRIPTION
Bug Fixes and improvements for smz3

fixed a trio of poses that weren't drawn properly for samus

slightly tweaked the default offset for the sprite

Fixed the remote layer for samu's sprite so she should appear in the proper place

fixed the sm event protocol, which was unintentionally not using the keysanity bits. also changed the math format to make it easier to update

draw the player color for local samus, and undraw when disabled. (causes a few artifacts when the game is trying to mess with her palette, but on the whole works well)