### PR TITLE
Typo fix

### DIFF
--- a/alttpo/SettingsWindow.as
+++ b/alttpo/SettingsWindow.as
@@ -144,7 +144,7 @@ class SettingsWindow {
     lblCrowdMessage.text = msg;
   }
 
-  private bool enablePvp;
+  private bool enablePvP;
   bool EnablePvP {
     get { return enablePvP; }
   }


### PR DESCRIPTION
I noticed this because having a `syncChests` private variable made the `::syncChests` namespacing break in the checkbox creation stanza.

Changing this didn't break the usage of `::enablePvP` though, so I'm actually still pretty confused. are variables case-insensitive? if so, why did the `::` thing break on `::syncChests`?