### PR TITLE
SM Enemy sync bugfixed

### DIFF
--- a/alttpo/LocalGameState.as
+++ b/alttpo/LocalGameState.as
@@ -3743,8 +3743,20 @@ class LocalGameState : GameState {
     uint players_len = players.length();
     for (uint i = 0; i < 0x20; i ++){
       bool take_host = true;
+
+      // skip elevators or the ship
+      switch(local.enemies[i].pointer){
+        case 0xD73F: continue;
+        case 0xD0BF: continue;
+        case 0xD07F: continue;
+      }
+      // if the "respawn when killed" flag is set, skip syncing this enemy
+      if(local.enemies[i].enemy_data[7] & 0x4000 == 0x4000){
+        //message("found a respawner");
+        continue;
+      }
       
-      if (!(local.timeInRoom < 5) && local.enemies[i].pointer == 0){continue;}
+      if (!(local.timeInRoom < 50) && local.enemies[i].pointer == 0){continue;}
       
       for (uint j = 0; j < players_len; j++) {
         auto @remote = players[j];
@@ -3753,10 +3765,10 @@ class LocalGameState : GameState {
         if (remote.ttl <= 0) continue;
         if (remote.team != team) continue;
         if (!remote.enemySyncEnabled) continue;
-        if (remote.timeInRoom < 5) continue;
+        if (remote.timeInRoom < 50) continue;
         if (!local.can_see_sm(remote)) continue;
         
-        if (local.timeInRoom < 5){
+        if (local.timeInRoom < 50){
           local.enemies[i].clone_to(remote.enemies[i]);
           local.enemies[i].host_index = remote.index;
           take_host = false;

--- a/alttpo/SM_Enemy.as
+++ b/alttpo/SM_Enemy.as
@@ -88,6 +88,19 @@ class SM_Enemy {
   void write(){
     uint bound; //determines how much memory to copy into enemy slot
     
+
+    // if the "respawn when killed" flag is set, skip syncing this enemy
+    if(enemy_data[7] & 0x4000 == 0x4000){
+      return;
+    }
+
+    // check if we currently are in a boss room
+    if (bus::read_u16(0x7e179c) != 0){
+      // if so, write hp only, then leave 0 hp causes problems, so write 1 and let each player get the kill
+      bus::write_u16(sm_enemy_bank + enemy_index*0x40 + 10*2, max(enemy_data[10],1));
+      return;
+    }
+
     switch(pointer){
       
       case 0x0000: {
@@ -108,12 +121,6 @@ class SM_Enemy {
       case 0xE87F: bound = 24; break;
       case 0xEaFF: bound = 24; break;
       default: bound = 32;
-    }
-  
-    
-    // if the "respawn when killed" flag is set, skip syncing this enemy
-    if(enemy_data[15] & 0b01000000 == 0b01000000){
-      return;
     }
     
     for(uint i = 0; i < bound; i++){


### PR DESCRIPTION

-Added delay when syncing new arrivals to the room to mitigate the race condition causing problems

-added check so that bosses only sync their health and leave all other fields alone

-program now correctly determines which enemies respawn when killed and excludes them from sync