### PR TITLE
Add additional check for "DR" in rom header title

### DIFF
--- a/alttpo/ROMMapping.as
+++ b/alttpo/ROMMapping.as
@@ -844,7 +844,7 @@ ROMMapping@ detect() {
     auto kind = title.slice(0, 2) + " v" + title.slice(2, 3);
     message("Recognized Berserker MultiWorld Door Randomizer " + kind + " randomized JP ROM version. Seed: " + seed);
     return DoorRandomizerMapping(kind, seed);
-  } else if ( (title.slice(0, 2) == "ER") && (title[5] == '_') ) {
+  } else if ( ((title.slice(0, 2) == "ER") || (title.slice(0,2) == "DR")) && (title[5] == '_') ) {
     // ALTTPR Entrance or Door Randomizer.
     //  0123456789
     // "ER002_1_1_164246190  "


### PR DESCRIPTION
I thought this was in ROMMapping for years but i guess not, the header was changed on aerinon's years ago but we never updated it to handle the new title. Better late than never I suppose.

Marked as draft pending light user testing from discord, but I don't see any real issue if you wanted to merge this early.